### PR TITLE
Removed EventCapableInterface from PhlyBlog\Compiler

### DIFF
--- a/src/PhlyBlog/Compiler.php
+++ b/src/PhlyBlog/Compiler.php
@@ -6,11 +6,9 @@ use DateTimezone;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventManager;
-use Zend\EventManager\EventsCapableInterface;
 
 class Compiler implements
-    EventManagerAwareInterface,
-    EventsCapableInterface
+    EventManagerAwareInterface
 {
     protected $events;
     protected $files;


### PR DESCRIPTION
When using PhlyBlog\Compiler I get the following error with latest ZF2 master:

```
PHP Fatal error: Class PhlyBlog\Compiler cannot implement previously implemented interface Zend\EventManager\EventsCapableInterface
```
