### PR TITLE
Fix tags listener resolution

### DIFF
--- a/src/Console/CompileCommand.php
+++ b/src/Console/CompileCommand.php
@@ -221,7 +221,7 @@ class CompileCommand extends Command
         }
 
         if ($flags['all'] || $flags['tag']) {
-            $listeners['entries by tag'] = $this->tags;
+            $listeners['entries by tag'] = $tags;
         }
 
         return $listeners;


### PR DESCRIPTION
I accidentally introduced an issue in the 2.0.0 release whereby getListeners was incorrectly resolving the `tags` listener based on property access, instead of the argument provided to the method.

Fixes #22
