### PR TITLE
Fix rendering of posts and pagination

### DIFF
--- a/src/Console/CompileCommand.php
+++ b/src/Console/CompileCommand.php
@@ -105,14 +105,15 @@ class CompileCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io    = new SymfonyStyle($input, $output);
-        $flags = $this->getFlags($input);
-        $tags  = $this->getTags();
+        $io        = new SymfonyStyle($input, $output);
+        $flags     = $this->getFlags($input);
+        $tags      = $this->getTags();
+        $listeners = $this->getListeners($flags, $tags);
 
         // Compile blog entries
         $io->title('Compiling Blog');
-        $io->write('<info>Compiling and sorting entries...</info>');
-        $io->progressStart();
+        $io->writeln('<info>Compiling and sorting entries...</info>');
+        $io->progressStart(1);
         $this->compiler->compile();
         $io->progressFinish();
 
@@ -120,9 +121,9 @@ class CompileCommand extends Command
         $this->generateTagCloud($io, $tags);
 
         // Compile everything else
-        foreach ($this->getListeners($flags, $tags) as $type => $listener) {
-            $io->write(sprintf('<info>Compiling %s</info>', $type));
-            $io->progressStart();
+        foreach ($listeners as $type => $listener) {
+            $io->writeln(sprintf('<info>Compiling %s</info>', $type));
+            $io->progressStart(1);
             $listener->compile();
             $io->progressFinish();
         }
@@ -168,8 +169,8 @@ class CompileCommand extends Command
         }
 
         $tagCloudGenerator = $this->config['cloud_callback'];
-        $io->write('<info>Creating and rendering tag cloud</info>');
-        $io->progressStart();
+        $io->writeln('<info>Creating and rendering tag cloud</info>');
+        $io->progressStart(1);
         $tagCloudGenerator($tags->getTagCloud(), $this->config, $this->container);
         $io->progressFinish();
     }


### PR DESCRIPTION
This patch fixes a number of issues with using the phly-blog:compile command to render posts and pagination files:

- It moves listener initialization earlier in the command, before any compilation is performed; this ensures that each listener is informed of what they need to compile and render during the compilation process. (Thanks, @rieschl!)
- It refactors `PhlyBlog\Console\ViewFactory` to do the following:
  - Ensure the Application instance is properly initialized; this is necessary so that some helpers, such as the Url helper, ar properly initialized and populated.
  - Adds a rendering strategy that resets the helper plugin manager on each iteration.
    This is necessary to ensure state is clean in each helper; otherwise, state aggregates, and we receive content duplicated once per page rendered.
  - Adds a response strategy that populates the layout from the renderered content.
- It fixes how progress is emitted, ensuring that users are informed of (a) **what** is being compiled, and (b) **when and how long** it took to complete.
