### PR TITLE
Add Compiler as a container service

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: "${{ runner.os }}-composer-"
 
       - name: "Install highest dependencies"
-        run: "composer update --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-interaction --no-progress"
 
       - name: "Tests"
         run: "vendor/bin/phpunit --coverage-clover=clover.xml --coverage-text"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#29](https://github.com/phly/PhlyBlog/pull/29) adds a `PhlyBlog\CompilerFactory`, and wires the `PhlyBlog\Compiler` service to be created via that factory.
 
 ### Changed
 
-- Nothing.
+- [#29](https://github.com/phly/PhlyBlog/pull/29) adds an optional `?Compiler $compiler = null` argument to the `CompileCommand` constructor. When provided, the command will use that `Compiler` instance. The `CompileCommandFactory` now pulls the `Compiler` service from the container and passes it for that argument.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.3",
         "laminas/laminas-cli": "^0.1.4",
         "laminas/laminas-console": "^2.5",
-        "laminas/laminas-dependency-plugin": "^1.0",
+        "laminas/laminas-dependency-plugin": "^1.0 || ^2.0",
         "laminas/laminas-eventmanager": "^3.0",
         "laminas/laminas-feed": "^2.5",
         "laminas/laminas-filter": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "laminas/laminas-uri": "^2.5",
         "laminas/laminas-validator": "^2.5",
         "laminas/laminas-view": "^2.5",
-        "phly/phly-common": "^2.0",
+        "phly/phly-common": "^2.0.1",
         "symfony/console": "^5.1"
     },
     "require-dev": {

--- a/src/Compiler/PhpFileFilter.php
+++ b/src/Compiler/PhpFileFilter.php
@@ -34,20 +34,22 @@ class PhpFileFilter extends FilterIterator
     {
         if (is_string($dirOrIterator)) {
             if (! is_dir($dirOrIterator)) {
-                throw new InvalidArgumentException('Expected a valid directory name');
+                throw new InvalidArgumentException(sprintf(
+                    'Expected a valid directory name; received "%s"',
+                    $dirOrIterator
+                ));
             }
 
             $dirOrIterator = new RecursiveDirectoryIterator($dirOrIterator);
         }
+
         if (! $dirOrIterator instanceof DirectoryIterator) {
             throw new InvalidArgumentException('Expected a DirectoryIterator');
         }
 
-        if ($dirOrIterator instanceof RecursiveIterator) {
-            $iterator = new RecursiveIteratorIterator($dirOrIterator);
-        } else {
-            $iterator = $dirOrIterator;
-        }
+        $iterator = $dirOrIterator instanceof RecursiveIterator
+            ? new RecursiveIteratorIterator($dirOrIterator)
+            : $dirOrIterator;
 
         parent::__construct($iterator);
         $this->rewind();

--- a/src/CompilerFactory.php
+++ b/src/CompilerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PhlyBlog;
+
+use PhlyBlog\Compiler\PhpFileFilter;
+use Psr\Container\ContainerInterface;
+
+class CompilerFactory
+{
+    public function __invoke(ContainerInterface $container): Compiler
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['blog'] ?? [];
+
+        return new Compiler(
+            new PhpFileFilter($config['posts_path'] ?? getcwd() . '/data/blog/')
+        );
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -209,6 +209,7 @@ class ConfigProvider
     {
         return [
             'factories' => [
+                Compiler::class               => CompilerFactory::class,
                 Console\CompileCommand::class => Console\CompileCommandFactory::class,
                 Console\View::class           => Console\ViewFactory::class,
             ],

--- a/src/Console/CompileCommand.php
+++ b/src/Console/CompileCommand.php
@@ -63,7 +63,8 @@ class CompileCommand extends Command
     public function __construct(
         array $config,
         ContainerInterface $container,
-        View $view
+        View $view,
+        ?Compiler $compiler = null
     ) {
         $this->config          = $config;
         $this->container       = $container;
@@ -71,12 +72,11 @@ class CompileCommand extends Command
         $this->compilerOptions = new CompilerOptions($config['options'] ?? []);
         $this->responseFile    = new ResponseFile();
         $this->writer          = new FileWriter();
-
-        new ResponseStrategy($this->writer, $this->responseFile, $view);
-
-        $this->compiler = new Compiler(
+        $this->compiler        = $compiler ?: new Compiler(
             new PhpFileFilter($config['posts_path'] ?? getcwd() . '/data/blog/')
         );
+
+        new ResponseStrategy($this->writer, $this->responseFile, $view);
 
         parent::__construct();
     }

--- a/src/Console/CompileCommandFactory.php
+++ b/src/Console/CompileCommandFactory.php
@@ -2,6 +2,7 @@
 
 namespace PhlyBlog\Console;
 
+use PhlyBlog\Compiler;
 use Psr\Container\ContainerInterface;
 
 class CompileCommandFactory
@@ -14,7 +15,8 @@ class CompileCommandFactory
         return new CompileCommand(
             $config,
             $container,
-            $container->get(View::class)
+            $container->get(View::class),
+            $container->get(Compiler::class)
         );
     }
 }

--- a/test/CompilerFactoryTest.php
+++ b/test/CompilerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PhlyBlogTest;
+
+use InvalidArgumentException;
+use Laminas\EventManager\EventManagerAwareInterface;
+use PhlyBlog\CompilerFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class CompilerFactoryTest extends TestCase
+{
+    public function defaultConfigurationProvider(): iterable
+    {
+        yield 'no config service' => [false, null];
+        yield 'empty config service' => [true, []];
+        yield 'empty blog config' => [true, ['blog' => []]];
+        yield 'empty posts_path config' => [true, ['blog' => ['posts_path' => null]]];
+    }
+
+    /**
+     * @dataProvider defaultConfigurationProvider
+     */
+    public function testFactoryUsesDefaultsWhenNoConfigurationPresent(
+        bool $hasConfig,
+        ?array $config
+    ): void {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('config')
+            ->willReturn($hasConfig);
+
+        if ($hasConfig) {
+            $container
+                ->expects($this->once())
+                ->method('get')
+                ->with('config')
+                ->willReturn($config);
+        }
+
+        $factory  = new CompilerFactory();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(getcwd() . '/data/blog');
+        $factory($container);
+    }
+
+    public function testFactoryUsesConfigurationToProduceCompilerWhenPresent(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn([
+                'blog' => [
+                    'posts_path' => __DIR__,
+                ],
+            ]);
+
+        $factory  = new CompilerFactory();
+
+        $this->assertInstanceOf(EventManagerAwareInterface::class, $factory($container));
+    }
+}


### PR DESCRIPTION
This patch adds the `PhlyBlog\Compiler` class as a service to the DI container, with a factory for creating it, and modifies the `CompileCommand` to optionally accept a `Compiler` instance to its constructor.
The `CompileCommandFactory` now pulls the `Compiler` service to inject it into the `CompileCommand` as well.
These changes allow users to add a delegator factory in order to listen to the `compile` event.

Fixes #28
