### PR TITLE
Make Compiler EventsCapable instead of EventManagerAware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#31](https://github.com/phly/PhlyBlog/pull/31) changes the `Compiler` to implement `EventsCapableInterface` instead of `EventManagerAwareInterface` (the latter is a superset of the former). Doing so ensures that any initializers for `EventManagerAwareInterface` do not trigger, which prevents double-injection of the `EventManager` instance, and thus prevents overwriting any listeners attached via delegator factories. The `setEventManager()` method is still defined.
 
 ### Deprecated
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5,18 +5,22 @@ namespace PhlyBlog;
 use DateTime;
 use DateTimeZone;
 use Laminas\EventManager\EventManager;
-use Laminas\EventManager\EventManagerAwareInterface;
 use Laminas\EventManager\EventManagerInterface;
+use Laminas\EventManager\EventsCapableInterface;
 use RuntimeException;
 
-class Compiler implements EventManagerAwareInterface
+class Compiler implements EventsCapableInterface
 {
     protected $events;
     protected $files;
 
-    public function __construct(Compiler\PhpFileFilter $files)
+    public function __construct(Compiler\PhpFileFilter $files, ?EventManagerInterface $eventManager = null)
     {
         $this->files = $files;
+
+        if ($eventManager) {
+            $this->setEventManager($eventManager);
+        }
     }
 
     public function setEventManager(EventManagerInterface $events)

--- a/src/CompilerFactory.php
+++ b/src/CompilerFactory.php
@@ -2,6 +2,7 @@
 
 namespace PhlyBlog;
 
+use Laminas\EventManager\EventManagerInterface;
 use PhlyBlog\Compiler\PhpFileFilter;
 use Psr\Container\ContainerInterface;
 
@@ -13,7 +14,8 @@ class CompilerFactory
         $config = $config['blog'] ?? [];
 
         return new Compiler(
-            new PhpFileFilter($config['posts_path'] ?? getcwd() . '/data/blog/')
+            new PhpFileFilter($config['posts_path'] ?? getcwd() . '/data/blog/'),
+            $container->get(EventManagerInterface::class)
         );
     }
 }


### PR DESCRIPTION
laminas-mvc creates an initializer for classes marked EventsManagerAware.  Since initializers run AFTER delegators, if you attempt to add any listeners via a delegator factory, they then get overwritten when a new EM instance is injected by the initializer.

Additionally, this patch modifies the `Compiler` to optionally accept an EM instance to the constructor, and the `CompilerFactory` to pull one from the container when creating an instance.

Fixes #30
